### PR TITLE
Fixed recursion between objects

### DIFF
--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -303,6 +303,10 @@ class ChromePhp
             return $object;
         }
 
+        //Mark this object as processed so we don't convert it twice and it
+        //Also avoid recursion when objects refer to each other
+        self::$processed[] = $object;
+
         $object_as_array = array();
 
         // first add the class name
@@ -314,7 +318,7 @@ class ChromePhp
 
             // same instance as parent object
             if ($value === $object || in_array($value, self::$processed, true)) {
-                $value = 'recursion - parent object';
+                $value = 'recursion - parent object [' . get_class($value) . ']';
             }
             $object_as_array[$key] = $this->_convert($value);
         }
@@ -342,7 +346,7 @@ class ChromePhp
 
             // same instance as parent object
             if ($value === $object || in_array($value, self::$processed, true)) {
-                $value = 'recursion - parent object';
+                $value = 'recursion - parent object [' . get_class($value) . ']';
             }
 
             $object_as_array[$type] = $this->_convert($value);

--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -139,6 +139,13 @@ class ChromePhp
     protected static $_instance;
 
     /**
+     * Prevent recursion when working with objects refering to each other
+     *
+     * @var array
+     */
+    protected static $processed = array();
+
+    /**
      * constructor
      */
     private function __construct()
@@ -269,6 +276,7 @@ class ChromePhp
             $value = $args[1];
         }
 
+        self::$processed = array();
         $value = $logger->_convert($value);
 
         $backtrace = debug_backtrace(false);
@@ -305,7 +313,7 @@ class ChromePhp
         foreach ($object_vars as $key => $value) {
 
             // same instance as parent object
-            if ($value === $object) {
+            if ($value === $object || in_array($value, self::$processed, true)) {
                 $value = 'recursion - parent object';
             }
             $object_as_array[$key] = $this->_convert($value);
@@ -333,7 +341,7 @@ class ChromePhp
             }
 
             // same instance as parent object
-            if ($value === $object) {
+            if ($value === $object || in_array($value, self::$processed, true)) {
                 $value = 'recursion - parent object';
             }
 


### PR DESCRIPTION
I needed ChromePHP to work with some classes referring to each other Example

DB
 ->Events
      ->MyEvent

myEvent
    ->target
          ->DB

I fixed it in a quick manner by creating an array of processed objects and added it to you check for recursion. It might not be the best way to fix this but it works pretty well for me.
