### PR TITLE
Update ChromePhp.php with debug()

### DIFF
--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -42,7 +42,12 @@ class ChromePhp
      * @var string
      */
     const LOG = 'log';
-
+    
+    /**
+     * @var string
+     */
+    const DEBUG = 'debug';
+    
     /**
      * @var string
      */
@@ -159,6 +164,18 @@ class ChromePhp
     {
         $args = func_get_args();
         return self::_log('', $args);
+    }
+    
+    /**
+     * logs a debug message to the console
+     *
+     * @param mixed $data,... unlimited OPTIONAL number of additional logs [...]
+     * @return void
+     */
+    public static function debug()
+    {
+        $args = func_get_args();
+        return self::_log(self::DEBUG, $args);
     }
 
     /**


### PR DESCRIPTION
Added debug() function to log to debug tab in console.
Is backwards compatible with current chrome plugin (just uses log).
