### PR TITLE
_log returns the class instance for method chaining

### DIFF
--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -245,29 +245,25 @@ class ChromePhp
      * internal logging call
      *
      * @param string $type
-     * @return void
+     * @return ChromePhp
      */
     protected static function _log($type, array $args)
     {
-        // nothing passed in, don't do anything
-        if (count($args) == 0 && $type != self::GROUP_END) {
-            return;
-        }
-
         $logger = self::getInstance();
 
-        $logger->_processed = array();
-
-        $logs = array();
-        foreach ($args as $arg) {
-            $logs[] = $logger->_convert($arg);
+        // nothing passed in, don't do anything
+        if (empty($args) && $type != self::GROUP_END) {
+            return $logger;
         }
+
+        $logger->_processed = array();
+        $logs = array_map(array($logger, '_convert'), $args);
 
         $backtrace = debug_backtrace(false);
         $level = $logger->getSetting(self::BACKTRACE_LEVEL);
 
         $backtrace_message = 'unknown';
-        if (isset($backtrace[$level]['file']) && isset($backtrace[$level]['line'])) {
+        if (isset($backtrace[$level]['file'], $backtrace[$level]['line'])) {
             $backtrace_message = $backtrace[$level]['file'] . ' : ' . $backtrace[$level]['line'];
         }
 

--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -273,7 +273,7 @@ class ChromePhp
 
         $logger->_addRow($logs, $backtrace_message, $type);
 
-        return self::getInstance();
+        return $logger;
     }
 
     /**

--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -272,6 +272,8 @@ class ChromePhp
         }
 
         $logger->_addRow($logs, $backtrace_message, $type);
+
+        return self::getInstance();
     }
 
     /**


### PR DESCRIPTION
So that you can do stuff like:

``` php
ChromePhp::group('Some Logs')
    ->log('A log message')
    ->log('Another log message')
    ->log('This can go on as long as you like.')
    ->groupEnd();
```

Which I think is pretty slick.
