### PR TITLE
Prevent Apache 500 internal server error, truncates logs that are too…

### DIFF
--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -420,7 +420,6 @@ class ChromePhp
 
 		while(mb_strlen($encdata) > self::HEADER_LIMIT)
 		{
-			$i++;
 			$shrinking = false;
 			// first remove regular status messages from tables from start to finish
 			// try to leave behind warnings, errors

--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -397,7 +397,7 @@ class ChromePhp
 
     protected function _writeHeader($data)
     {
-		$encdata = $this->_shrinkLog($data);
+        $encdata = $this->_shrinkLog($data);
         header(self::HEADER_NAME . ': ' . $encdata);
     }
 
@@ -426,7 +426,7 @@ class ChromePhp
 			// try to leave behind warnings, errors
 			foreach($data['rows'] as $j => $row)
 			{
-				if($row[2] === 'table')
+				if(isset($row[2]) && $row[2] === 'table')
 				{
 					foreach($row[0] as $k => $ro)
 					{
@@ -443,7 +443,7 @@ class ChromePhp
 			if(!$shrinking)
 			{
 				// remove regular logs
-				if($row[0][2] !== 'error')
+				if(isset($row[0][2]) && $row[0][2] !== 'error')
 				{
 					unset($data['rows']);
 					$shrinking = true;

--- a/composer.json
+++ b/composer.json
@@ -1,15 +1,21 @@
 {
-    "name": "ccampbell/chromephp",
+    "name": "frankforte/chromephp",
     "type": "library",
     "description": "Log variables to the Chrome console (via Chrome Logger Google Chrome extension).",
     "keywords": ["log","logging"],
-    "homepage": "http://github.com/ccampbell/chromephp",
+    "homepage": "http://github.com/frankforte/chromephp",
     "license": "Apache-2.0",
     "authors": [
         {
             "name": "Craig Campbell",
             "email": "iamcraigcampbell@gmail.com",
             "homepage": "http://craig.is",
+            "role": "Developer"
+        },
+		{
+            "name": "Frank Forte",
+            "email": "frank.forte@gmail.com",
+            "homepage": "http://www.frankforte.ca",
             "role": "Developer"
         }
     ],


### PR DESCRIPTION
ChromePHP is meant to help developers debug.  Ironically, it can cause a 500 internal server error when served from Apache if the logs are too large, which gives absolutely no information from the application about why it failed.

This commit checks the size of the header, and if it is too large, it removes some logs until it is small enough, first attempting to remove regular "status" logs, and if it is still too large, the rest of the logs. It even plays nice with the table log.