### PR TITLE
PHP 8.2 compatibility fix

### DIFF
--- a/ChromePhp.php
+++ b/ChromePhp.php
@@ -402,7 +402,7 @@ class ChromePhp
      */
     protected function _encode($data)
     {
-        return base64_encode(utf8_encode(json_encode($data)));
+        return base64_encode(mb_convert_encoding(json_encode($data), "UTF-8"));
     }
 
     /**


### PR DESCRIPTION
utf8_encode() is deprecated in PHP 8.2